### PR TITLE
[Bugfix] Tx_Phpunit_Database_TestCase::importStdDb in TYPO3 6.x

### DIFF
--- a/Classes/Database/TestCase.php
+++ b/Classes/Database/TestCase.php
@@ -285,8 +285,11 @@ abstract class Tx_Phpunit_Database_TestCase extends Tx_Phpunit_TestCase {
 	 * @return void
 	 */
 	protected function importStdDb() {
-		/** @var SqlExpectedSchemaService $sqlExpectedSchemaService */
-		$sqlExpectedSchemaService = GeneralUtility::makeInstance('TYPO3\\CMS\\Install\\Service\\SqlExpectedSchemaService');
+        /* @var $objectManager TYPO3\CMS\Extbase\Object\ObjectManager */
+        $objectManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
+        /** @var $sqlExpectedSchemaService TYPO3\CMS\Install\Service\SqlExpectedSchemaService */
+        $sqlExpectedSchemaService = $objectManager->get('TYPO3\\CMS\\Install\\Service\\SqlExpectedSchemaService');
+
 		$databaseDefinitions = $sqlExpectedSchemaService->getTablesDefinitionString(TRUE);
 
 		$this->importDatabaseDefinitions($databaseDefinitions);


### PR DESCRIPTION
Fix method 'Tx_Phpunit_Database_TestCase::importStdDb' in TYPO3 6.x (class 'TYPO3\CMS\Install\Service\SqlExpectedSchemaService' must be instanciated via objectMamanger, because the service contain objects, which are injected via notation - @inject)